### PR TITLE
 bugfix int overflow

### DIFF
--- a/jbig2_mmr.c
+++ b/jbig2_mmr.c
@@ -73,7 +73,7 @@ jbig2_decode_mmr_init(Jbig2MmrCtx *mmr, int width, int height, const byte *data,
     mmr->bit_index = 0;
 
     for (i = 0; i < size && i < 4; i++)
-        word |= (data[i] << ((3 - i) << 3));
+        word |= ((uint32_t)data[i] << ((3 - i) << 3));
     mmr->word = word;
 }
 


### PR DESCRIPTION
There is a problem of left shift overflow When I run the undefine type test of oss-fuzz.