### PR TITLE
Libpng16

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,14 +10,14 @@ include_HEADERS = jbig2.h
 
 AM_CFLAGS = $(XCFLAGS)
 
-libjbig2dec_la_LDFLAGS = -version-info @JBIG2DEC_LT_CURRENT@:@JBIG2DEC_LT_REVISION@:@JBIG2DEC_LT_AGE@ -no-undefined
+libjbig2dec_la_LDFLAGS = -version-info @JBIG2DEC_LT_CURRENT@:@JBIG2DEC_LT_REVISION@:@JBIG2DEC_LT_AGE@ -no-undefined -lpng16
 libjbig2dec_la_SOURCES = jbig2.c \
 	jbig2_arith.c jbig2_arith_int.c jbig2_arith_iaid.c jbig2_huffman.c jbig2_hufftab.c \
 	jbig2_segment.c jbig2_page.c \
 	jbig2_symbol_dict.c jbig2_text.c \
 	jbig2_generic.c jbig2_refinement.c jbig2_mmr.c \
 	jbig2_halftone.c \
-	jbig2_image.c jbig2_image_pbm.c \
+	jbig2_image.c jbig2_image_pbm.c jbig2_image_png.c \
 	os_types.h config_types.h config_win32.h \
 	jbig2.h jbig2_priv.h jbig2_image.h \
 	jbig2_arith.h jbig2_arith_iaid.h jbig2_arith_int.h \

--- a/Makefile.unix
+++ b/Makefile.unix
@@ -28,7 +28,7 @@ libjbig2dec.a: $(LIB_OBJS)
 	ar cru $@ $^
 
 jbig2dec: $(APP_OBJS) libjbig2dec.a
-	$(CC) -o $@ $^ -lpng -lz
+	$(CC) -o $@ $^ -lpng16 -lz
 
 all: jbig2dec libjbig2dec.a
 

--- a/configure.ac.in
+++ b/configure.ac.in
@@ -48,7 +48,7 @@ if test "x$ac_cv_want_libpng" != "xno"; then
   fi
   dnl libpng requires pow() which may be in libm
   AC_SEARCH_LIBS([pow], [m])
-  AC_CHECK_LIB([png], [png_create_write_struct], [
+  AC_CHECK_LIB([png16], [png_create_write_struct], [
     AC_CHECK_LIB([z], [deflate], [
       AC_DEFINE(HAVE_LIBPNG, 1, [Define if libpng is available (-lpng16)])
       PNG_LIBS="-lpng16 -lz"

--- a/configure.ac.in
+++ b/configure.ac.in
@@ -50,8 +50,8 @@ if test "x$ac_cv_want_libpng" != "xno"; then
   AC_SEARCH_LIBS([pow], [m])
   AC_CHECK_LIB([png], [png_create_write_struct], [
     AC_CHECK_LIB([z], [deflate], [
-      AC_DEFINE(HAVE_LIBPNG, 1, [Define if libpng is available (-lpng)])
-      PNG_LIBS="-lpng -lz"
+      AC_DEFINE(HAVE_LIBPNG, 1, [Define if libpng is available (-lpng16)])
+      PNG_LIBS="-lpng16 -lz"
       AC_LIBOBJ([jbig2_image_png])
       have_libpng="yes"
     ])


### PR DESCRIPTION
I spent some time getting this repo built on Mint 20.3. It required to explicitly depend on libpng16 instead of libpng to get it compiled.

When I now compile it with
./autogen.sh CFLAGS=-DDUMP_SYMDICT=1
I finally get the symbols found in the document als little .png-files, as the dump function is not yet implemented.

https://stackoverflow.com/questions/72361820/how-to-read-out-the-properties-of-the-symbol-dictionary-used-by-the-jbig2-algori