### PR TITLE
fix: error: unknown type name ‘bool’

### DIFF
--- a/jbig2_image.c
+++ b/jbig2_image.c
@@ -485,7 +485,7 @@ jbig2_image_get_pixel(Jbig2Image *image, int x, int y)
 
 /* set an individual pixel value in an image */
 void
-jbig2_image_set_pixel(Jbig2Image *image, int x, int y, bool value)
+jbig2_image_set_pixel(Jbig2Image *image, int x, int y, int value)
 {
     const int w = image->width;
     const int h = image->height;

--- a/jbig2_image.h
+++ b/jbig2_image.h
@@ -37,6 +37,6 @@ Jbig2Image *jbig2_image_resize(Jbig2Ctx *ctx, Jbig2Image *image, uint32_t width,
 int jbig2_image_compose(Jbig2Ctx *ctx, Jbig2Image *dst, Jbig2Image *src, int x, int y, Jbig2ComposeOp op);
 
 int jbig2_image_get_pixel(Jbig2Image *image, int x, int y);
-void jbig2_image_set_pixel(Jbig2Image *image, int x, int y, bool value);
+void jbig2_image_set_pixel(Jbig2Image *image, int x, int y, int value);
 
 #endif /* _JBIG2_IMAGE_H */


### PR DESCRIPTION
fix this build error

```
jbig2dec/jbig2_image.h:40:61: error: unknown type name ‘bool’
   40 | void jbig2_image_set_pixel(Jbig2Image *image, int x, int y, bool value);
      |                                                             ^~~~
```

i am using `cmake` to build `jbig2dec`

<details>
<summary>
CMakeLists.txt
</summary>


```
cmake_minimum_required(VERSION 3.16)
project(jbig2_browser_polyfill)

set(CMAKE_C_STANDARD 99)
set(CMAKE_CXX_STANDARD 17)



# add_subdirectory(src/third_party/jbig2dec)

set(JBIG2DEC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/jbig2dec)

# You should NOT compile these, because:
# jbig2dec.c → CLI tool (you already have your own)
# jbig2_image_png.c → requires libpng/zlib (not needed for your use case)
# jbig2_image_pbm.c → irrelevant output format
set(JBIG2DEC_SOURCES
    ${JBIG2DEC_DIR}/jbig2_arith.c
    ${JBIG2DEC_DIR}/jbig2_arith_int.c
    ${JBIG2DEC_DIR}/jbig2_arith_iaid.c
    ${JBIG2DEC_DIR}/jbig2_huffman.c
    ${JBIG2DEC_DIR}/jbig2_hufftab.c
    ${JBIG2DEC_DIR}/jbig2_segment.c
    ${JBIG2DEC_DIR}/jbig2_page.c
    ${JBIG2DEC_DIR}/jbig2_symbol_dict.c
    ${JBIG2DEC_DIR}/jbig2_text.c
    ${JBIG2DEC_DIR}/jbig2_halftone.c
    ${JBIG2DEC_DIR}/jbig2_generic.c
    ${JBIG2DEC_DIR}/jbig2_refinement.c
    ${JBIG2DEC_DIR}/jbig2_mmr.c
    ${JBIG2DEC_DIR}/jbig2_image.c
    ${JBIG2DEC_DIR}/jbig2.c
)

add_library(jbig2dec STATIC ${JBIG2DEC_SOURCES})

target_include_directories(jbig2dec PUBLIC
    ${JBIG2DEC_DIR}
)

target_compile_options(jbig2dec PRIVATE
    -Wall
    -Wextra
    -Wno-unused-parameter
    -O2
)
```


</details>


### alternatives

instead of `int`, we could also use a smaller type like `char`
